### PR TITLE
1week

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application-security.yml

--- a/records/1Week_KimWonHee.md
+++ b/records/1Week_KimWonHee.md
@@ -1,0 +1,32 @@
+# 1Week_KimWonHee.md
+
+## Title: [1Week] 김원희
+
+### 미션 요구사항 분석 & 체크리스트
+
+---
+
+- [x] 호감상대 삭제
+  - [x] 로그인한 사람만 가능
+  - [x] 삭제처리 전 해당 항목에 대한 소유권 확인
+  - [x] rq.redirectWithMsg 함수 사용하여 성공여부 알림
+  - [x] 삭제 후 /likeablePerson/list로 리다이렉트
+
+### N주차 미션 요약
+
+---
+
+**[접근 방법]**
+
+
+- 호감상대 항목에 대한 소유권이 로그인한 본인에게 있는지 확인하기 위해 rq와 Principal 객체를 사용했다.
+- rq.redirectWithMsg 함수를 사용하기 위해 likeablePersonService.delete의 return형을 RsData\<LikeablePerson>로 하여 
+삭제와 동시에 반환하도록 했다.
+
+
+
+
+**[특이사항]**
+
+delete 메서드를 작성할 때 @Transactional 어노테이션을 하지 않아서 계속 db에서 삭제되지 않는 문제가 발생했었다. <br>
+insert, update, delete 동작시에는 @Transactional을 통해 데이터 베이스에 commit을 해야한다는 것을 다시 상기하게 되었다.

--- a/src/main/java/com/ll/gramgram/DataNotFoundException.java
+++ b/src/main/java/com/ll/gramgram/DataNotFoundException.java
@@ -1,0 +1,10 @@
+package com.ll.gramgram;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "entity not found")
+public class DataNotFoundException extends RuntimeException {
+    public DataNotFoundException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -5,16 +5,22 @@ import com.ll.gramgram.base.rsData.RsData;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
+import com.ll.gramgram.boundedContext.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.security.Principal;
 import java.util.List;
 
 @Controller
@@ -23,6 +29,7 @@ import java.util.List;
 public class LikeablePersonController {
     private final Rq rq;
     private final LikeablePersonService likeablePersonService;
+    private final MemberService memberService;
 
     @GetMapping("/add")
     public String showAdd() {
@@ -58,5 +65,16 @@ public class LikeablePersonController {
         }
 
         return "usr/likeablePerson/list";
+    }
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/delete/{id}")
+    public String likeablePersonDelete(Principal principal, @PathVariable("id") Long id){
+        LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id);
+        if(!rq.getMember().getUsername().equals(principal.getName())){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "삭제 권한이 없습니다.");
+        }
+        RsData<LikeablePerson> deleteRsLikeablePerson = likeablePersonService.delete(likeablePerson);
+
+        return rq.redirectWithMsg("/likeablePerson/list", deleteRsLikeablePerson);
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -22,23 +22,30 @@ public class LikeablePerson {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
+
     @CreatedDate
     private LocalDateTime createDate;
+
     @LastModifiedDate
     private LocalDateTime modifyDate;
 
     @ManyToOne
     private InstaMember fromInstaMember; // 호감을 표시한 사람(인스타 멤버)
+
     private String fromInstaMemberUsername; // 혹시 몰라서 기록
+
     @ManyToOne
     private InstaMember toInstaMember; // 호감을 받은 사람(인스타 멤버)
+
     private String toInstaMemberUsername; // 혹시 몰라서 기록
+
     private int attractiveTypeCode; // 매력포인트(1=외모, 2=성격, 3=능력)
 
     public String getAttractiveTypeDisplayName() {
         return switch (attractiveTypeCode) {
             case 1 -> "외모";
             case 2 -> "성격";
+
             default -> "능력";
         };
     }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Integer> {
+public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -1,5 +1,6 @@
 package com.ll.gramgram.boundedContext.likeablePerson.service;
 
+import com.ll.gramgram.DataNotFoundException;
 import com.ll.gramgram.base.rsData.RsData;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -47,5 +49,21 @@ public class LikeablePersonService {
 
     public List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId) {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
+    }
+
+    public LikeablePerson getLikeablePerson(Long id) {
+        Optional<LikeablePerson> likeablePerson = likeablePersonRepository.findById(id.intValue());
+        if (likeablePerson.isPresent()) {
+            return likeablePerson.get();
+        } else{
+            throw new DataNotFoundException("likeable not found!");
+        }
+    }
+
+    @Transactional
+    public RsData<LikeablePerson> delete(LikeablePerson likeablePerson){
+        likeablePersonRepository.delete(likeablePerson);
+
+        return RsData.of("S-1", "삭제되었습니다.", likeablePerson);
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -52,7 +52,7 @@ public class LikeablePersonService {
     }
 
     public LikeablePerson getLikeablePerson(Long id) {
-        Optional<LikeablePerson> likeablePerson = likeablePersonRepository.findById(id.intValue());
+        Optional<LikeablePerson> likeablePerson = likeablePersonRepository.findById(id);
         if (likeablePerson.isPresent()) {
             return likeablePerson.get();
         } else{

--- a/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
@@ -26,14 +26,20 @@ public class Member {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
+
     @CreatedDate // 아래 칼럼에는 값이 자동으로 들어간다.(INSERT 할 때)
     private LocalDateTime createDate;
+
     @LastModifiedDate // 아래 칼럼에는 값이 자동으로 들어간다.(UPDATE 할 때 마다)
     private LocalDateTime modifyDate;
+
     private String providerTypeCode; // 일반회원인지, 카카오로 가입한 회원인지, 구글로 가입한 회원인지
+
     @Column(unique = true)
     private String username;
+
     private String password;
+
     @OneToOne // 1:1
     @Setter // memberService::updateInstaMember 함수 때문에
     private InstaMember instaMember;
@@ -57,4 +63,5 @@ public class Member {
     public boolean hasConnectedInstaMember() {
         return instaMember != null;
     }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,28 +3,12 @@ server:
 spring:
   profiles:
     active: dev
+    include: security
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://127.0.0.1:3306/gram__dev?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
     username: wh
     password: wh1234
-  security:
-    oauth2:
-      client:
-        registration:
-          kakao:
-            clientId: 148954a25338de7b4d8ef568fb7cdd96
-            scope:
-            client-name: Kakao
-            authorization-grant-type: authorization_code
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
-            client-authentication-method: POST
-        provider:
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-name-attribute: id
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/main/resources/templates/usr/likeablePerson/list.html
+++ b/src/main/resources/templates/usr/likeablePerson/list.html
@@ -21,7 +21,7 @@
                 <span class="toInstaMember_username" th:text="${likeablePerson.toInstaMember.username}"></span>
                 <span class="toInstaMember_attractiveTypeDisplayName"
                       th:text="${likeablePerson.attractiveTypeDisplayName}"></span>
-                <a th:href="@{|delete/${likeablePerson.id}|}" onclick="return confirm('정말로 삭제하시겠습니까?');">삭제</a>
+                <a th:if="${@rq.login}" class="btn btn-link" th:href="@{|delete/${likeablePerson.id}|}" onclick="return confirm('정말로 삭제하시겠습니까?');">삭제</a>
             </li>
         </ul>
     </th:block>

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -149,4 +149,22 @@ public class LikeablePersonControllerTests {
                         """.stripIndent().trim())));
         ;
     }
+
+    @Test
+    @DisplayName("호감상대 삭제")
+    @WithUserDetails("user3")
+    void t006() throws Exception {
+        //WHEN
+        ResultActions resultActions = mvc
+                .perform(get("/likeablePerson/delete/2"))
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("likeablePersonDelete"))
+                .andExpect(status().is3xxRedirection());
+        ;
+
+    }
 }


### PR DESCRIPTION
# 1Week_KimWonHee.md

## Title: [1Week] 김원희

### 미션 요구사항 분석 & 체크리스트

---

- [x] 호감상대 삭제
  - [x] 로그인한 사람만 가능
  - [x] 삭제처리 전 해당 항목에 대한 소유권 확인
  - [x] rq.redirectWithMsg 함수 사용하여 성공여부 알림
  - [x] 삭제 후 /likeablePerson/list로 리다이렉트

### N주차 미션 요약

---

**[접근 방법]**


- 호감상대 항목에 대한 소유권이 로그인한 본인에게 있는지 확인하기 위해 rq와 Principal 객체를 사용했다.
- rq.redirectWithMsg 함수를 사용하기 위해 likeablePersonService.delete의 return형을 RsData\<LikeablePerson>로 하여 
삭제와 동시에 반환하도록 했다.




**[특이사항]**

delete 메서드를 작성할 때 @Transactional 어노테이션을 하지 않아서 계속 db에서 삭제되지 않는 문제가 발생했었다. <br>
insert, update, delete 동작시에는 @Transactional을 통해 데이터 베이스에 commit을 해야한다는 것을 다시 상기하게 되었다.